### PR TITLE
override AuditEvent.view to explicitly wrap anything regardless of doc_type

### DIFF
--- a/auditcare/models.py
+++ b/auditcare/models.py
@@ -48,6 +48,17 @@ class AuditEvent(Document):
     event_date = DateTimeProperty(default=getdate)
     description = StringProperty() #particular instance details of this audit event
 
+    @classmethod
+    def view(cls, view_name, wrapper=None, classes=None, **params):
+        if cls is AuditEvent and not classes:
+            wrapper = wrapper or (lambda row: cls.wrap(row['doc']))
+        return super(AuditEvent, cls).view(
+            view_name,
+            wrapper=wrapper,
+            classes=classes,
+            **params
+        )
+
     @property
     def summary(self):
         try:
@@ -113,7 +124,6 @@ class ModelActionAudit(AuditEvent):
 
     next_id = StringProperty() #the doc_id of the next revision
     prev_id = StringProperty() #the doc_id of the previous revision
-
 
     def next(self):
         if self.next_id is not None:


### PR DESCRIPTION
This makes it compatible with couchdbkit 0.6.4
