### PR TITLE
use new urls module

### DIFF
--- a/auditcare/urls.py
+++ b/auditcare/urls.py
@@ -1,5 +1,5 @@
 import traceback
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from auditcare.utils import logout_template, login_template
 
 


### PR DESCRIPTION
`django.conf.urls.defaults` is deprecated and removed in Django 1.6